### PR TITLE
Add `base64encode` and `base64decode` into builtin functions

### DIFF
--- a/function/base64.go
+++ b/function/base64.go
@@ -50,6 +50,10 @@ func Base64Decode(vm *otto.Otto) {
 			return otto.Value{}
 		}
 		sb, err := base64.StdEncoding.DecodeString(s)
+		if err != nil {
+			fmt.Println("ERROR", err)
+			return otto.Value{}
+		}
 		v, err := vm.ToValue(string(sb))
 		if err != nil {
 			fmt.Println("ERROR", err)

--- a/function/base64.go
+++ b/function/base64.go
@@ -1,0 +1,60 @@
+package function
+
+import (
+	"fmt"
+
+	"github.com/robertkrimen/otto"
+	"encoding/base64"
+)
+
+// Base64Encode registers base64 encode function
+// Name: base64encode.
+// Arguments: string.
+// Return: string.
+func Base64Encode(vm *otto.Otto) {
+	vm.Set("base64encode", func(call otto.FunctionCall) otto.Value {
+		a0 := call.Argument(0)
+		if !a0.IsString() {
+			fmt.Println("ERROR", "base64encode(string)")
+			return otto.Value{}
+		}
+		s, err := a0.ToString()
+		if err != nil {
+			fmt.Println("ERROR", err)
+			return otto.Value{}
+		}
+		s = base64.StdEncoding.EncodeToString([]byte(s))
+		v, err := vm.ToValue(s)
+		if err != nil {
+			fmt.Println("ERROR", err)
+			return otto.Value{}
+		}
+		return v
+	})
+}
+
+// Base64Decode registers base64 decode function
+// Name: base64decode.
+// Arguments: string.
+// Return: string.
+func Base64Decode(vm *otto.Otto) {
+	vm.Set("base64decode", func(call otto.FunctionCall) otto.Value {
+		a0 := call.Argument(0)
+		if !a0.IsString() {
+			fmt.Println("ERROR", "base64decode(string)")
+			return otto.Value{}
+		}
+		s, err := a0.ToString()
+		if err != nil {
+			fmt.Println("ERROR", err)
+			return otto.Value{}
+		}
+		sb, err := base64.StdEncoding.DecodeString(s)
+		v, err := vm.ToValue(string(sb))
+		if err != nil {
+			fmt.Println("ERROR", err)
+			return otto.Value{}
+		}
+		return v
+	})
+}

--- a/vm.go
+++ b/vm.go
@@ -19,4 +19,6 @@ func RegisterFunctions() {
 	function.MD5(VM)
 	function.Must(VM)
 	function.Exit(VM)
+	function.Base64Decode(VM)
+	function.Base64Encode(VM)
 }


### PR DESCRIPTION
Add # .

Changes proposed in this pull request:
- Add `base64encode` and `base64decode` into builtin functions

When one api required basic auth:

```
// This is a frank test case file
// -- https://github.com/txthinking/frank

url = "http://localhost:5000/v2.0"

POST /zone/login
header["Accept"] = "application/json"
header["Content-Type"] = "application/json"
header["Authorization"] = "Basic " + base64encode("jeremaihloo1024@gmail.com:admin")
json = {
    "email":"jeremaihloo1024@gmail.com",
	"password":"admin"
}

Response
must(status==200)
```

@txthinking Is there another way to do this instead of adding builtin functions ?

Sorry for my chinglish and bad PR comments.
